### PR TITLE
Fixed rolling file extension methods namespace regression

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,9 +3,9 @@ image: Visual Studio 2015
 configuration: Release
 install:
   - ps: mkdir -Force ".\build\" | Out-Null
-  - ps: Invoke-WebRequest "https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/install.ps1" -OutFile ".\build\installcli.ps1"
+  - ps: Invoke-WebRequest "https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.ps1" -OutFile ".\build\installcli.ps1"
   - ps: $env:DOTNET_INSTALL_DIR = "$pwd\.dotnetcli"
-  - ps: '& .\build\installcli.ps1 -InstallDir "$env:DOTNET_INSTALL_DIR" -NoPath'
+  - ps: '& .\build\installcli.ps1 -InstallDir "$env:DOTNET_INSTALL_DIR" -NoPath -Version 1.0.0-preview2-002823'
   - ps: $env:Path = "$env:DOTNET_INSTALL_DIR;$env:Path"
 build_script:
 - ps: ./Build.ps1

--- a/src/Serilog.Sinks.RollingFile/RollingFileLoggerConfigurationExtensions.cs
+++ b/src/Serilog.Sinks.RollingFile/RollingFileLoggerConfigurationExtensions.cs
@@ -17,8 +17,9 @@ using Serilog.Configuration;
 using Serilog.Core;
 using Serilog.Events;
 using Serilog.Formatting.Display;
+using Serilog.Sinks.RollingFile;
 
-namespace Serilog.Sinks.RollingFile
+namespace Serilog
 {
     public static class RollingFileLoggerConfigurationExtensions
     {


### PR DESCRIPTION
Somehow this one slipped through the cracks; the extension methods should be in `Serilog` to ensure source-compatibility with v1.5 apps.
