### PR TITLE
Include the encoding parameter in the constructor

### DIFF
--- a/src/Serilog.Sinks.RollingFile/RollingFileLoggerConfigurationExtensions.cs
+++ b/src/Serilog.Sinks.RollingFile/RollingFileLoggerConfigurationExtensions.cs
@@ -51,6 +51,7 @@ namespace Serilog
         /// For unrestricted growth, pass null. The default is 1 GB.</param>
         /// <param name="retainedFileCountLimit">The maximum number of log files that will be retained,
         /// including the current log file. For unlimited retention, pass null. The default is 31.</param>
+        /// <param name="encoding">Character encoding used to write the text file. The default is UTF-8.</param>
         /// <param name="buffered">Indicates if flushing to the output file can be buffered or not. The default
         /// is false.</param>
         /// <returns>Configuration object allowing method chaining.</returns>
@@ -64,11 +65,12 @@ namespace Serilog
             long? fileSizeLimitBytes = DefaultFileSizeLimitBytes,
             int? retainedFileCountLimit = DefaultRetainedFileCountLimit,
             LoggingLevelSwitch levelSwitch = null,
+            Encoding encoding = null,
             bool buffered = false)
         {
             var formatter = new MessageTemplateTextFormatter(outputTemplate, formatProvider);
             return RollingFile(sinkConfiguration, formatter, pathFormat, restrictedToMinimumLevel, fileSizeLimitBytes,
-                retainedFileCountLimit, levelSwitch, buffered);
+                retainedFileCountLimit, levelSwitch, encoding, buffered);
         }
 
         /// <summary>
@@ -90,6 +92,7 @@ namespace Serilog
         /// For unrestricted growth, pass null. The default is 1 GB.</param>
         /// <param name="retainedFileCountLimit">The maximum number of log files that will be retained,
         /// including the current log file. For unlimited retention, pass null. The default is 31.</param>
+        /// <param name="encoding">Character encoding used to write the text file. The default is UTF-8.</param>
         /// <param name="buffered">Indicates if flushing to the output file can be buffered or not. The default
         /// is false.</param>
         /// <returns>Configuration object allowing method chaining.</returns>
@@ -102,11 +105,12 @@ namespace Serilog
             long? fileSizeLimitBytes = DefaultFileSizeLimitBytes,
             int? retainedFileCountLimit = DefaultRetainedFileCountLimit,
             LoggingLevelSwitch levelSwitch = null,
+            Encoding encoding = null,
             bool buffered = false)
         {
             if (sinkConfiguration == null) throw new ArgumentNullException(nameof(sinkConfiguration));
             if (formatter == null) throw new ArgumentNullException(nameof(formatter));
-            var sink = new RollingFileSink(pathFormat, formatter, fileSizeLimitBytes, retainedFileCountLimit, buffered: buffered);
+            var sink = new RollingFileSink(pathFormat, formatter, fileSizeLimitBytes, retainedFileCountLimit, encoding: encoding, buffered: buffered);
             return sinkConfiguration.Sink(sink, restrictedToMinimumLevel, levelSwitch);
         }
     }

--- a/src/Serilog.Sinks.RollingFile/RollingFileLoggerConfigurationExtensions.cs
+++ b/src/Serilog.Sinks.RollingFile/RollingFileLoggerConfigurationExtensions.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System;
+using System.Text;
 using Serilog.Configuration;
 using Serilog.Core;
 using Serilog.Events;


### PR DESCRIPTION
The encoding parameter (optional) it's included in the constructor but it was not included in this static class. So now, when you use the RollingFile extension method you'll have the option to send the encoding parameter. Not quite sure yet how to send this parameter from the configuration file.

I took this from the issue #337
