### PR TITLE
Changed the UTF Encoding instance to avoid inserting the BOM character

### DIFF
--- a/src/Serilog.Sinks.RollingFile/Sinks/RollingFile/RollingFileSink.cs
+++ b/src/Serilog.Sinks.RollingFile/Sinks/RollingFile/RollingFileSink.cs
@@ -74,7 +74,7 @@ namespace Serilog.Sinks.RollingFile
             _textFormatter = textFormatter;
             _fileSizeLimitBytes = fileSizeLimitBytes;
             _retainedFileCountLimit = retainedFileCountLimit;
-            _encoding = encoding ?? Encoding.UTF8;
+            _encoding = encoding ?? new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
             _buffered = buffered;
         }
 

--- a/src/Serilog.Sinks.RollingFile/project.json
+++ b/src/Serilog.Sinks.RollingFile/project.json
@@ -23,7 +23,8 @@
       "dependencies": {
         "System.IO": "4.1.0",
         "System.IO.FileSystem.Primitives": "4.0.1",
-        "System.Runtime.InteropServices": "4.1.0"
+        "System.Runtime.InteropServices": "4.1.0",
+        "System.Text.Encoding.Extensions": "4.0.11"
       }
     }
   }


### PR DESCRIPTION
Fix to solve issue https://github.com/serilog/serilog-sinks-file/issues/9 (it applies here too)
