### PR TITLE
Revert "Changed the UTF Encoding instance to avoid inserting the BOM character"

### DIFF
--- a/src/Serilog.Sinks.RollingFile/Sinks/RollingFile/RollingFileSink.cs
+++ b/src/Serilog.Sinks.RollingFile/Sinks/RollingFile/RollingFileSink.cs
@@ -74,7 +74,7 @@ namespace Serilog.Sinks.RollingFile
             _textFormatter = textFormatter;
             _fileSizeLimitBytes = fileSizeLimitBytes;
             _retainedFileCountLimit = retainedFileCountLimit;
-            _encoding = encoding ?? new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+            _encoding = encoding ?? Encoding.UTF8;
             _buffered = buffered;
         }
 

--- a/src/Serilog.Sinks.RollingFile/project.json
+++ b/src/Serilog.Sinks.RollingFile/project.json
@@ -23,8 +23,7 @@
       "dependencies": {
         "System.IO": "4.1.0",
         "System.IO.FileSystem.Primitives": "4.0.1",
-        "System.Runtime.InteropServices": "4.1.0",
-        "System.Text.Encoding.Extensions": "4.0.11"
+        "System.Runtime.InteropServices": "4.1.0"
       }
     }
   }


### PR DESCRIPTION
Reverts serilog/serilog-sinks-rollingfile#11

@christianhxc sorry, I realised the split second after merging this that your PR targeted `master` - we need to merge this into `dev` first, so reverting here.
