### PR TITLE
Add option to retain files based on age

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,13 @@ For the same reason, only **the most recent 31 files** are retained by default (
     .WriteTo.RollingFile("log-{Date}.txt", retainedFileCountLimit: null)
 ```
 
+In addition, it is possible to set a maximum age for the log files that will be retained. To set this limit, pass the `retainedFileAgeLimit` parameter.
+
+```csharp
+    .WriteTo.RollingFile("log-{Date}.txt", retainedFileAgeLimit: TimeSpan.FromDays(31))
+```
+Note that this will be applied *after* the limit set by `retainedFileCountLimit`. To ignore the file count limit and only use file age, `retainedFileCountLimit` should be set to `null`.
+
 ### XML `<appSettings>` configuration
 
 To use the rolling file sink with the [Serilog.Settings.AppSettings](https://github.com/serilog/serilog-settings-appsettings) package, first install that package if you haven't already done so:

--- a/src/Serilog.Sinks.RollingFile/RollingFileLoggerConfigurationExtensions.cs
+++ b/src/Serilog.Sinks.RollingFile/RollingFileLoggerConfigurationExtensions.cs
@@ -53,6 +53,9 @@ namespace Serilog
         /// including the current log file. For unlimited retention, pass null. The default is 31.</param>
         /// <param name="buffered">Indicates if flushing to the output file can be buffered or not. The default
         /// is false.</param>
+        /// <param name="retainedFileAgeLimit">The maximum age of log files that will be retained,
+        /// including the current log file. For unlimited retention, pass null (default).
+        /// This will be applied after <paramref name="retainedFileCountLimit"/>.</param>
         /// <returns>Configuration object allowing method chaining.</returns>
         /// <remarks>The file will be written using the UTF-8 character set.</remarks>
         public static LoggerConfiguration RollingFile(
@@ -64,11 +67,12 @@ namespace Serilog
             long? fileSizeLimitBytes = DefaultFileSizeLimitBytes,
             int? retainedFileCountLimit = DefaultRetainedFileCountLimit,
             LoggingLevelSwitch levelSwitch = null,
-            bool buffered = false)
+            bool buffered = false,
+            TimeSpan? retainedFileAgeLimit = null)
         {
             var formatter = new MessageTemplateTextFormatter(outputTemplate, formatProvider);
             return RollingFile(sinkConfiguration, formatter, pathFormat, restrictedToMinimumLevel, fileSizeLimitBytes,
-                retainedFileCountLimit, levelSwitch, buffered);
+                retainedFileCountLimit, levelSwitch, buffered, retainedFileAgeLimit);
         }
 
         /// <summary>
@@ -92,6 +96,9 @@ namespace Serilog
         /// including the current log file. For unlimited retention, pass null. The default is 31.</param>
         /// <param name="buffered">Indicates if flushing to the output file can be buffered or not. The default
         /// is false.</param>
+        /// <param name="retainedFileAgeLimit">The maximum age of log files that will be retained,
+        /// including the current log file. For unlimited retention, pass null (default).
+        /// This will be applied after <paramref name="retainedFileCountLimit"/>.</param>
         /// <returns>Configuration object allowing method chaining.</returns>
         /// <remarks>The file will be written using the UTF-8 character set.</remarks>
         public static LoggerConfiguration RollingFile(
@@ -102,11 +109,12 @@ namespace Serilog
             long? fileSizeLimitBytes = DefaultFileSizeLimitBytes,
             int? retainedFileCountLimit = DefaultRetainedFileCountLimit,
             LoggingLevelSwitch levelSwitch = null,
-            bool buffered = false)
+            bool buffered = false,
+            TimeSpan? retainedFileAgeLimit = null)
         {
             if (sinkConfiguration == null) throw new ArgumentNullException(nameof(sinkConfiguration));
             if (formatter == null) throw new ArgumentNullException(nameof(formatter));
-            var sink = new RollingFileSink(pathFormat, formatter, fileSizeLimitBytes, retainedFileCountLimit, buffered: buffered);
+            var sink = new RollingFileSink(pathFormat, formatter, fileSizeLimitBytes, retainedFileCountLimit, buffered: buffered, retainedFileAgeLimit: retainedFileAgeLimit);
             return sinkConfiguration.Sink(sink, restrictedToMinimumLevel, levelSwitch);
         }
     }

--- a/src/Serilog.Sinks.RollingFile/Sinks/RollingFile/RetentionPolicies/FileAgeRetentionPolicy.cs
+++ b/src/Serilog.Sinks.RollingFile/Sinks/RollingFile/RetentionPolicies/FileAgeRetentionPolicy.cs
@@ -1,0 +1,75 @@
+﻿// Copyright 2013-2016 Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Serilog.Sinks.RollingFile.RetentionPolicies;
+using System;
+using System.IO;
+using System.Linq;
+using Serilog.Debugging;
+
+namespace Serilog.Sinks.RollingFile.Sinks.RollingFile.RetentionPolicies
+{
+    internal class FileAgeRetentionPolicy : IRetentionPolicy
+    {
+        private readonly TemplatedPathRoller _roller;
+        private readonly TimeSpan _retainedFileAgeLimit;
+
+        public FileAgeRetentionPolicy(TemplatedPathRoller roller, TimeSpan retainedFileAgeLimit)
+        {
+            if (roller == null)
+                throw new ArgumentNullException("roller");
+
+            _roller = roller;
+            _retainedFileAgeLimit = retainedFileAgeLimit;
+        }
+
+        public void Apply(string currentFilePath)
+        {
+            var currentFileName = Path.GetFileName(currentFilePath);
+
+            // We consider the current file to exist, even if nothing's been written yet,
+            // because files are only opened on response to an event being processed.
+            var potentialMatches = Directory.GetFiles(_roller.LogFileDirectory, _roller.DirectorySearchPattern)
+                .Select(Path.GetFileName)
+                .Union(new[] { currentFileName });
+
+            var newestFirst = _roller
+                .SelectMatches(potentialMatches)
+                .OrderByDescending(m => m.Date)
+                .ThenByDescending(m => m.SequenceNumber)
+                .Select(m => new { m.Filename, m.Date });
+
+            var maxAge = DateTimeOffset.Now - _retainedFileAgeLimit;
+
+            var toRemove = newestFirst
+                .Where(f => StringComparer.OrdinalIgnoreCase.Compare(currentFileName, f.Filename) != 0
+                            && f.Date < maxAge)
+                .Select(f => f.Filename)
+                .ToList();
+
+            foreach (var obsolete in toRemove)
+            {
+                var fullPath = Path.Combine(_roller.LogFileDirectory, obsolete);
+                try
+                {
+                    System.IO.File.Delete(fullPath);
+                }
+                catch (Exception ex)
+                {
+                    SelfLog.WriteLine("Error {0} while removing obsolete file {1}", ex, fullPath);
+                }
+            }
+        }
+    }
+}

--- a/src/Serilog.Sinks.RollingFile/Sinks/RollingFile/RetentionPolicies/FileAgeRetentionPolicy.cs
+++ b/src/Serilog.Sinks.RollingFile/Sinks/RollingFile/RetentionPolicies/FileAgeRetentionPolicy.cs
@@ -12,13 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Serilog.Sinks.RollingFile.RetentionPolicies;
 using System;
 using System.IO;
 using System.Linq;
 using Serilog.Debugging;
 
-namespace Serilog.Sinks.RollingFile.Sinks.RollingFile.RetentionPolicies
+namespace Serilog.Sinks.RollingFile.RetentionPolicies
 {
     internal class FileAgeRetentionPolicy : IRetentionPolicy
     {

--- a/src/Serilog.Sinks.RollingFile/Sinks/RollingFile/RetentionPolicies/FileAgeRetentionPolicy.cs
+++ b/src/Serilog.Sinks.RollingFile/Sinks/RollingFile/RetentionPolicies/FileAgeRetentionPolicy.cs
@@ -30,6 +30,9 @@ namespace Serilog.Sinks.RollingFile.Sinks.RollingFile.RetentionPolicies
             if (roller == null)
                 throw new ArgumentNullException("roller");
 
+            if (retainedFileAgeLimit <= TimeSpan.Zero)
+                throw new ArgumentException("Zero or negative value provided; retained file age limit must be a positive timespan");
+
             _roller = roller;
             _retainedFileAgeLimit = retainedFileAgeLimit;
         }

--- a/src/Serilog.Sinks.RollingFile/Sinks/RollingFile/RetentionPolicies/FileCountRetentionPolicy.cs
+++ b/src/Serilog.Sinks.RollingFile/Sinks/RollingFile/RetentionPolicies/FileCountRetentionPolicy.cs
@@ -1,0 +1,76 @@
+﻿// Copyright 2013-2016 Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Serilog.Debugging;
+using System;
+using System.IO;
+using System.Linq;
+
+namespace Serilog.Sinks.RollingFile.RetentionPolicies
+{
+    internal class FileCountRetentionPolicy : IRetentionPolicy
+    {
+        private readonly TemplatedPathRoller _roller;
+        private readonly int? _retainedFileCountLimit;
+
+        public FileCountRetentionPolicy(TemplatedPathRoller roller, int? retainedFileCountLimit)
+        {
+            if (roller == null)
+                throw new ArgumentNullException("roller");
+
+            if (retainedFileCountLimit.HasValue && retainedFileCountLimit < 1)
+                throw new ArgumentException("Zero or negative value provided; retained file count limit must be at least 1");
+
+            _roller = roller;
+            _retainedFileCountLimit = retainedFileCountLimit;
+        }
+
+        public void Apply(string currentFilePath)
+        {
+            if (_retainedFileCountLimit == null) return;
+
+            var currentFileName = Path.GetFileName(currentFilePath);
+
+            // We consider the current file to exist, even if nothing's been written yet,
+            // because files are only opened on response to an event being processed.
+            var potentialMatches = Directory.GetFiles(_roller.LogFileDirectory, _roller.DirectorySearchPattern)
+                .Select(Path.GetFileName)
+                .Union(new[] { currentFileName });
+
+            var newestFirst = _roller
+                .SelectMatches(potentialMatches)
+                .OrderByDescending(m => m.Date)
+                .ThenByDescending(m => m.SequenceNumber)
+                .Select(m => m.Filename);
+
+            var toRemove = newestFirst
+                .Where(n => StringComparer.OrdinalIgnoreCase.Compare(currentFileName, n) != 0)
+                .Skip(_retainedFileCountLimit.Value - 1)
+                .ToList();
+
+            foreach (var obsolete in toRemove)
+            {
+                var fullPath = Path.Combine(_roller.LogFileDirectory, obsolete);
+                try
+                {
+                    System.IO.File.Delete(fullPath);
+                }
+                catch (Exception ex)
+                {
+                    SelfLog.WriteLine("Error {0} while removing obsolete file {1}", ex, fullPath);
+                }
+            }
+        }
+    }
+}

--- a/src/Serilog.Sinks.RollingFile/Sinks/RollingFile/RetentionPolicies/IRetentionPolicy.cs
+++ b/src/Serilog.Sinks.RollingFile/Sinks/RollingFile/RetentionPolicies/IRetentionPolicy.cs
@@ -1,0 +1,25 @@
+﻿// Copyright 2013-2016 Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Serilog.Sinks.RollingFile.RetentionPolicies
+{
+    internal interface IRetentionPolicy
+    {
+        /// <summary>
+        /// Applies the retention policy to the current file path.
+        /// </summary>
+        /// <param name="currentFilePath">Path to the file the policy will be applied to.</param>
+        void Apply(string currentFilePath);
+    }
+}

--- a/src/Serilog.Sinks.RollingFile/Sinks/RollingFile/RollingFileSink.cs
+++ b/src/Serilog.Sinks.RollingFile/Sinks/RollingFile/RollingFileSink.cs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -25,7 +24,6 @@ using Serilog.Events;
 using Serilog.Formatting;
 using Serilog.Sinks.File;
 using Serilog.Sinks.RollingFile.RetentionPolicies;
-using Serilog.Sinks.RollingFile.Sinks.RollingFile.RetentionPolicies;
 
 namespace Serilog.Sinks.RollingFile
 {

--- a/test/Serilog.Sinks.RollingFile.Tests/project.json
+++ b/test/Serilog.Sinks.RollingFile.Tests/project.json
@@ -12,7 +12,6 @@
     "warningsAsErrors": true
   },
   "frameworks": {
-    "net4.5.2": {},
     "netcoreapp1.0": {
       "dependencies": {
         "Microsoft.NETCore.App": {
@@ -24,6 +23,7 @@
         "dnxcore50",
         "portable-net45+win8"
       ]
-    }
+    },
+    "net4.5.2": {}
   }
 }


### PR DESCRIPTION
The current implementation of the rolling file sink supports a file count retention policy. This works well for single-process environments, but in a multi-process environment where the log files are exclusively locked, the number of files quickly ramps up. Without a very generous file count limit (or no limit at all), log files quickly disappear, which makes it very hard to trace back a couple of days (or even hours) when troubleshooting reported issues.

This change offers an alternative retention policy by also setting an age limit for files. Intuitively enough, any log files older than the maximum age will be removed. Being able to control file retention based on their age and not just the number of files seems like a common enough use case that it should be part of the core rolling file sink.

Right now I've implemented this by moving the retention policy into an `IRetentionPolicy` interface, and adding two implementations for `retainedFileCountLimit` and `retainedFileAgeLimit`, respectively. These implementations are then created internally based on the `RollingFileSink` constructor parameters. I haven't exposed this interface publicly, but it could be used to add support for custom retention policies.
