### PR TITLE
Added {Hour} and {HalfHour} specifiers.

### DIFF
--- a/src/Serilog.Sinks.RollingFile/Sinks/RollingFile/RollingFileSink.cs
+++ b/src/Serilog.Sinks.RollingFile/Sinks/RollingFile/RollingFileSink.cs
@@ -130,7 +130,6 @@ namespace Serilog.Sinks.RollingFile
 
             // We only take one attempt at it because repeated failures
             // to open log files REALLY slow an app down.
-
             _nextCheckpoint = _roller.GetNextCheckpoint(now);
 
             var existingFiles = Enumerable.Empty<string>();

--- a/src/Serilog.Sinks.RollingFile/Sinks/RollingFile/RollingFileSink.cs
+++ b/src/Serilog.Sinks.RollingFile/Sinks/RollingFile/RollingFileSink.cs
@@ -141,13 +141,13 @@ namespace Serilog.Sinks.RollingFile
             }
             catch (DirectoryNotFoundException) { }
 
-            var latestForThisDateTime = _roller
+            var latestForThisCheckpoint = _roller
                 .SelectMatches(existingFiles)
                 .Where(m => m.DateTime == currentCheckpoint)
                 .OrderByDescending(m => m.SequenceNumber)
                 .FirstOrDefault();
 
-            var sequence = latestForThisDateTime != null ? latestForThisDateTime.SequenceNumber : 0;
+            var sequence = latestForThisCheckpoint != null ? latestForThisCheckpoint.SequenceNumber : 0;
 
             const int maxAttempts = 3;
             for (var attempt = 0; attempt < maxAttempts; attempt++)

--- a/src/Serilog.Sinks.RollingFile/Sinks/RollingFile/RollingLogFile.cs
+++ b/src/Serilog.Sinks.RollingFile/Sinks/RollingFile/RollingLogFile.cs
@@ -18,16 +18,16 @@ namespace Serilog.Sinks.RollingFile
 {
     class RollingLogFile
     {
-        public RollingLogFile(string filename, DateTime date, int sequenceNumber)
+        public RollingLogFile(string filename, DateTime dateTime, int sequenceNumber)
         {
             Filename = filename;
-            Date = date;
+            DateTime = dateTime;
             SequenceNumber = sequenceNumber;
         }
 
         public string Filename { get; }
 
-        public DateTime Date { get; }
+        public DateTime DateTime { get; }
 
         public int SequenceNumber { get; }
     }

--- a/src/Serilog.Sinks.RollingFile/Sinks/RollingFile/Specifier.cs
+++ b/src/Serilog.Sinks.RollingFile/Sinks/RollingFile/Specifier.cs
@@ -1,0 +1,118 @@
+﻿using System;
+
+namespace Serilog.Sinks.RollingFile.Sinks.RollingFile
+{
+    internal class Specifier
+    {
+        internal const string OldStyleDateToken = "{0}";
+
+        internal const string DateToken = "{Date}";
+        internal const string HourToken = "{Hour}";
+        internal const string HalfHourToken = "{HalfHour}";
+
+        internal const string DateFormat = "yyyyMMdd";
+        internal const string HourFormat = "yyyyMMddHH";
+        internal const string HalfHourFormat = "yyyyMMddHHmm";
+
+        internal static readonly TimeSpan DateInterval = TimeSpan.FromDays(1);
+        internal static readonly TimeSpan HourInterval = TimeSpan.FromHours(1);
+        internal static readonly TimeSpan HalfHourInterval = TimeSpan.FromMinutes(30);
+
+        //-------------------
+
+        public static readonly Specifier Date = new Specifier(SpecifierType.Date);
+        public static readonly Specifier Hour = new Specifier(SpecifierType.Hour);
+        public static readonly Specifier HalfHour = new Specifier(SpecifierType.HalfHour);
+
+        //-------------------
+
+
+        public SpecifierType Type { get; }
+        public string Name { get; }
+        public string Token { get; }
+        public string Format { get; }
+        public TimeSpan Interval { get; }
+
+        Specifier(SpecifierType type)
+        {
+            switch (type)
+            {
+                case SpecifierType.Date:
+                    Token = Specifier.DateToken;
+                    Format = Specifier.DateFormat;
+                    Interval = Specifier.DateInterval;
+                    break;
+
+                case SpecifierType.Hour:
+                    Token = Specifier.HourToken;
+                    Format = Specifier.HourFormat;
+                    Interval = Specifier.HourInterval;
+                    break;
+
+                case SpecifierType.HalfHour:
+                    Token = Specifier.HalfHourToken;
+                    Format = Specifier.HalfHourFormat;
+                    Interval = Specifier.HalfHourInterval;
+                    break;
+            }
+
+            Type = type;
+            Name = (Token != null ? Token.Replace("{", string.Empty).Replace("}", string.Empty) : Token);
+        }
+
+        public DateTime GetCurrentCheckpoint(DateTime instant)
+        {
+            if (Type == SpecifierType.Hour)
+            {
+                return instant.Date.AddHours(instant.Hour);
+            }
+            else if (Type == SpecifierType.HalfHour)
+            {
+                DateTime auxDT = instant.Date.AddHours(instant.Hour);
+                if (instant.Minute >= 30)
+                    auxDT = auxDT.AddMinutes(30);
+                return auxDT;
+            }
+
+            return instant.Date;
+        }
+
+        public DateTime GetNextCheckpoint(DateTime instant)
+        {
+            DateTime currentCheckpoint = GetCurrentCheckpoint(instant);
+            return currentCheckpoint.Add(Interval);
+        }
+
+        //-------------
+
+        internal static Specifier GetFromTemplate(string template)
+        {
+            if (!string.IsNullOrWhiteSpace(template))
+            {
+                if (template.Contains(Specifier.DateToken))
+                {
+                    return Specifier.Date;
+                }
+                else if (template.Contains(Specifier.HourToken))
+                {
+                    return Specifier.Hour;
+                }
+                else if (template.Contains(Specifier.HalfHourToken))
+                {
+                    return Specifier.HalfHour;
+                }
+            }
+
+            return null;
+        }
+
+        //-------------
+
+        internal enum SpecifierType
+        {
+            Date,
+            Hour,
+            HalfHour
+        }
+    }
+}

--- a/src/Serilog.Sinks.RollingFile/Sinks/RollingFile/TemplatedPathRoller.cs
+++ b/src/Serilog.Sinks.RollingFile/Sinks/RollingFile/TemplatedPathRoller.cs
@@ -29,17 +29,41 @@ namespace Serilog.Sinks.RollingFile
         const string OldStyleDateSpecifier = "{0}";
         const string DateSpecifier = "{Date}";
         const string DateFormat = "yyyyMMdd";
+        const string HourSpecifier = "{Hour}";
+        const string HourFormat = "yyyyMMddHH";
+        const string HalfHourSpecifier = "{HalfHour}";
+        const string HalfHourFormat = "yyyyMMddHHmm";
         const string DefaultSeparator = "-";
+
+        const string MatcherMarkSpecifier = "date";
+        const string MatcherMarkInc = "inc";
 
         readonly string _pathTemplate;
         readonly Regex _filenameMatcher;
+        readonly SpecifierTypeEnum _specifierType = SpecifierTypeEnum.None;
+        // Concret used Date or Hour specifier.
+        readonly string _usedSpecifier = string.Empty;
+        readonly string _usedFormat = string.Empty;
 
         public TemplatedPathRoller(string pathTemplate)
         {
             if (pathTemplate == null) throw new ArgumentNullException(nameof(pathTemplate));
+
             if (pathTemplate.Contains(OldStyleDateSpecifier))
                 throw new ArgumentException("The old-style date specifier " + OldStyleDateSpecifier +
                     " is no longer supported, instead please use " + DateSpecifier);
+
+            int numSpecifiers = 0;
+            if (pathTemplate.Contains(DateSpecifier))
+                numSpecifiers++;
+            if (pathTemplate.Contains(HourSpecifier))
+                numSpecifiers++;
+            if (pathTemplate.Contains(HalfHourSpecifier))
+                numSpecifiers++;
+            if (numSpecifiers > 1)
+                throw new ArgumentException("The date, hour and half-hour specifiers (" + 
+                    DateSpecifier + "," + HourSpecifier + "," + HalfHourSpecifier +
+                    ") cannot be used at the same time");
 
             var directory = Path.GetDirectoryName(pathTemplate);
             if (string.IsNullOrEmpty(directory))
@@ -51,26 +75,57 @@ namespace Serilog.Sinks.RollingFile
 
             if (directory.Contains(DateSpecifier))
                 throw new ArgumentException("The date cannot form part of the directory name");
+            if (directory.Contains(HourSpecifier))
+                throw new ArgumentException("The hour specifiers cannot form part of the directory name");
+            if (directory.Contains(HalfHourSpecifier))
+                throw new ArgumentException("The half-hour specifiers cannot form part of the directory name");
 
             var filenameTemplate = Path.GetFileName(pathTemplate);
-            if (!filenameTemplate.Contains(DateSpecifier))
+            if (!filenameTemplate.Contains(DateSpecifier) && 
+                !filenameTemplate.Contains(HourSpecifier) &&
+                !filenameTemplate.Contains(HalfHourSpecifier))
             {
+                // If the file name doesn't use any of the admitted specifiers then it is added the date specifier
+                // as de default one.
                 filenameTemplate = Path.GetFileNameWithoutExtension(filenameTemplate) + DefaultSeparator +
                     DateSpecifier + Path.GetExtension(filenameTemplate);
             }
 
-            var indexOfSpecifier = filenameTemplate.IndexOf(DateSpecifier, StringComparison.Ordinal);
+            //---
+            // From this point forward we don't reference the Date or Hour concret specifiers and formats : 
+            // we will reference only the one set as "used" (_usedSpecifier and _usedFormat).
+
+            if (filenameTemplate.Contains(DateSpecifier))
+            {
+                _usedSpecifier = DateSpecifier;
+                _usedFormat = DateFormat;
+                _specifierType = SpecifierTypeEnum.Date;
+            }
+            else if (filenameTemplate.Contains(HourSpecifier))
+            {
+                _usedSpecifier = HourSpecifier;
+                _usedFormat = HourFormat;
+                _specifierType = SpecifierTypeEnum.Hour;
+            }
+            else if (filenameTemplate.Contains(HalfHourSpecifier))
+            {
+                _usedSpecifier = HalfHourSpecifier;
+                _usedFormat = HalfHourFormat;
+                _specifierType = SpecifierTypeEnum.HalfHour;
+            }
+
+            var indexOfSpecifier = filenameTemplate.IndexOf(_usedSpecifier, StringComparison.Ordinal);
             var prefix = filenameTemplate.Substring(0, indexOfSpecifier);
-            var suffix = filenameTemplate.Substring(indexOfSpecifier + DateSpecifier.Length);
+            var suffix = filenameTemplate.Substring(indexOfSpecifier + _usedSpecifier.Length);
             _filenameMatcher = new Regex(
                 "^" +
                 Regex.Escape(prefix) +
-                "(?<date>\\d{" + DateFormat.Length + "})" +
-                "(?<inc>_[0-9]{3,}){0,1}" +
+                "(?<" + MatcherMarkSpecifier + ">\\d{" + _usedFormat.Length + "})" +
+                "(?<" + MatcherMarkInc + ">_[0-9]{3,}){0,1}" +
                 Regex.Escape(suffix) +
                 "$");
 
-            DirectorySearchPattern = filenameTemplate.Replace(DateSpecifier, "*");
+            DirectorySearchPattern = filenameTemplate.Replace(_usedSpecifier, "*");
             LogFileDirectory = directory;
             _pathTemplate = Path.Combine(LogFileDirectory, filenameTemplate);
         }
@@ -81,12 +136,14 @@ namespace Serilog.Sinks.RollingFile
 
         public void GetLogFilePath(DateTime date, int sequenceNumber, out string path)
         {
-            var tok = date.ToString(DateFormat, CultureInfo.InvariantCulture);
+            DateTime currentCheckpoint = GetCurrentCheckpoint(date);
+
+            var tok = currentCheckpoint.ToString(_usedFormat, CultureInfo.InvariantCulture);
 
             if (sequenceNumber != 0)
                 tok += "_" + sequenceNumber.ToString("000", CultureInfo.InvariantCulture);
 
-            path = _pathTemplate.Replace(DateSpecifier, tok);
+            path = _pathTemplate.Replace(_usedSpecifier, tok);
         }
 
         public IEnumerable<RollingLogFile> SelectMatches(IEnumerable<string> filenames)
@@ -97,26 +154,68 @@ namespace Serilog.Sinks.RollingFile
                 if (match.Success)
                 {
                     var inc = 0;
-                    var incGroup = match.Groups["inc"];
+                    var incGroup = match.Groups[MatcherMarkInc];
                     if (incGroup.Captures.Count != 0)
                     {
                         var incPart = incGroup.Captures[0].Value.Substring(1);
                         inc = int.Parse(incPart, CultureInfo.InvariantCulture);
                     }
 
-                    DateTime date;
-                    var datePart = match.Groups["date"].Captures[0].Value;
+                    DateTime dateTime;
+                    var dateTimePart = match.Groups[MatcherMarkSpecifier].Captures[0].Value;
                     if (!DateTime.TryParseExact(
-                        datePart,
-                        DateFormat,
+                        dateTimePart,
+                        _usedFormat,
                         CultureInfo.InvariantCulture,
                         DateTimeStyles.None,
-                        out date))
+                        out dateTime))
                         continue;
 
-                    yield return new RollingLogFile(filename, date, inc);
+                    yield return new RollingLogFile(filename, dateTime, inc);
                 }
             }
         }
+
+        public DateTime GetCurrentCheckpoint(DateTime date)
+        {
+            if (_specifierType == SpecifierTypeEnum.Hour)
+            {
+                return date.Date.AddHours(date.Hour);
+            }
+            else if (_specifierType == SpecifierTypeEnum.HalfHour)
+            {
+                DateTime auxDT = date.Date.AddHours(date.Hour);
+                if (date.Minute >= 30)
+                    auxDT = auxDT.AddMinutes(30);
+                return auxDT;
+            }
+
+            return date.Date;
+        }
+
+        public DateTime GetNextCheckpoint(DateTime date)
+        {
+            DateTime currentCheckpoint = GetCurrentCheckpoint(date);
+
+            if (_specifierType == SpecifierTypeEnum.Hour)
+            {
+                return currentCheckpoint.AddHours(1);
+            }
+            else if (_specifierType == SpecifierTypeEnum.HalfHour)
+            {
+                return currentCheckpoint.AddMinutes(30);
+            }
+
+            return currentCheckpoint.AddDays(1);
+        }
     }
-} 
+
+    enum SpecifierTypeEnum
+    {
+        None,
+        Date,
+        Hour,
+        HalfHour
+    }
+
+}

--- a/test/Serilog.Sinks.RollingFile.Tests/TemplatedPathRollerTests.cs
+++ b/test/Serilog.Sinks.RollingFile.Tests/TemplatedPathRollerTests.cs
@@ -121,7 +121,7 @@ namespace Serilog.Sinks.RollingFile.Tests
             var roller = new TemplatedPathRoller("log-{Date}.txt");
             const string newer = "log-20150101.txt";
             const string older = "log-20141231.txt";
-            var matched = roller.SelectMatches(new[] { older, newer }).OrderByDescending(m => m.Date).Select(m => m.Filename).ToArray();
+            var matched = roller.SelectMatches(new[] { older, newer }).OrderByDescending(m => m.DateTime).Select(m => m.Filename).ToArray();
             Assert.Equal(new[] { newer, older }, matched);
         }
     }


### PR DESCRIPTION
This PR corresponds to the issue #22 .

This development adds two new specifiers to the currently admitted {Date}: {Hour} and {HalfHour}
The behaviour is obvius.

Please, feel free to change the token {HalfHour} by the one you consider better (you only have to change the value of the constant TemplatedPathRoller.HalfHourSpecifier).

One thing to have in mind when using it is that the three specifiers shouldn't be used at the same or different time on the same path as it could be confusing with an unexpected result.

Thanks.
Jose
