### PR TITLE
General tidy-up

### DIFF
--- a/src/Serilog.Sinks.RollingFile/Serilog.Sinks.RollingFile.xproj
+++ b/src/Serilog.Sinks.RollingFile/Serilog.Sinks.RollingFile.xproj
@@ -4,11 +4,10 @@
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
-
   <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>a3e6e5b4-995f-4c3d-9673-a4b6000f4e21</ProjectGuid>
-    <RootNamespace>Serilog.Sinks.RollingFile</RootNamespace>
+    <RootNamespace>Serilog</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
     <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
   </PropertyGroup>

--- a/src/Serilog.Sinks.RollingFile/Sinks/RollingFile/IOErrors.cs
+++ b/src/Serilog.Sinks.RollingFile/Sinks/RollingFile/IOErrors.cs
@@ -1,0 +1,31 @@
+﻿// Copyright 2013-2016 Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.IO;
+
+namespace Serilog.Sinks.RollingFile
+{
+    static class IOErrors
+    {
+        public static bool IsLockedFile(IOException ex)
+        {
+#if HRESULTS
+            var errorCode = System.Runtime.InteropServices.Marshal.GetHRForException(ex) & ((1 << 16) - 1);
+            return errorCode == 32 || errorCode == 33;
+#else
+            return true;
+#endif
+        }
+    }
+}

--- a/src/Serilog.Sinks.RollingFile/Sinks/RollingFile/RollingFileSink.cs
+++ b/src/Serilog.Sinks.RollingFile/Sinks/RollingFile/RollingFileSink.cs
@@ -12,11 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 using System;
 using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices;
 using System.Text;
 using Serilog.Core;
 using Serilog.Debugging;
@@ -100,7 +98,7 @@ namespace Serilog.Sinks.RollingFile
 
             lock (_syncRoot)
             {
-                if (_isDisposed) throw new ObjectDisposedException("The rolling file has been disposed.");
+                if (_isDisposed) throw new ObjectDisposedException("The rolling log file has been disposed.");
 
                 AlignCurrentFileTo(Clock.DateTimeNow);
 
@@ -166,8 +164,7 @@ namespace Serilog.Sinks.RollingFile
                 }
                 catch (IOException ex)
                 {
-                    var errorCode = Marshal.GetHRForException(ex) & ((1 << 16) - 1);
-                    if (errorCode == 32 || errorCode == 33)
+                    if (IOErrors.IsLockedFile(ex))
                     {
                         SelfLog.WriteLine("Rolling file target {0} was locked, attempting to open next in sequence (attempt {1})", path, attempt + 1);
                         sequence++;

--- a/src/Serilog.Sinks.RollingFile/Sinks/RollingFile/TemplatedPathRoller.cs
+++ b/src/Serilog.Sinks.RollingFile/Sinks/RollingFile/TemplatedPathRoller.cs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Serilog.Sinks.RollingFile.Sinks.RollingFile;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -26,8 +25,7 @@ namespace Serilog.Sinks.RollingFile
     //    Logs/log-{Date}.txt
     //
     class TemplatedPathRoller
-    {
-        
+    {        
         const string DefaultSeparator = "-";
 
         const string SpecifierMatchGroup = "specifier";
@@ -41,41 +39,19 @@ namespace Serilog.Sinks.RollingFile
         {
             if (pathTemplate == null) throw new ArgumentNullException(nameof(pathTemplate));
 
-            if (pathTemplate.Contains(Specifier.OldStyleDateToken))
-                throw new ArgumentException("The old-style date specifier " + Specifier.OldStyleDateToken +
-                    " is no longer supported, instead please use " + Specifier.Date.Token);
-
-            int numSpecifiers = 0;
-            if (pathTemplate.Contains(Specifier.Date.Token))
-                numSpecifiers++;
-            if (pathTemplate.Contains(Specifier.Hour.Token))
-                numSpecifiers++;
-            if (pathTemplate.Contains(Specifier.HalfHour.Token))
-                numSpecifiers++;
-            if (numSpecifiers > 1)
-                throw new ArgumentException("The date, hour and half-hour specifiers (" +
-                    Specifier.Date.Token + "," + Specifier.Hour.Token + "," + Specifier.HalfHour.Token +
-                    ") cannot be used at the same time");
-
             var directory = Path.GetDirectoryName(pathTemplate);
             if (string.IsNullOrEmpty(directory))
-            {
                 directory = Directory.GetCurrentDirectory();
-            }
-
-            directory = Path.GetFullPath(directory);
 
             Specifier directorySpecifier;
             if (Specifier.TryGetSpecifier(directory, out directorySpecifier))
-            {
                 throw new ArgumentException($"The {directorySpecifier.Token} specifier cannot form part of the directory name.");
-            }
+
+            directory = Path.GetFullPath(directory);
 
             var filenameTemplate = Path.GetFileName(pathTemplate);
             if (!Specifier.TryGetSpecifier(filenameTemplate, out _specifier))
             {
-                // If the file name doesn't use any of the admitted specifiers then it is set the date specifier
-                // as de default one.
                 _specifier = Specifier.Date;
                 filenameTemplate = Path.GetFileNameWithoutExtension(filenameTemplate) + DefaultSeparator +
                     _specifier.Token + Path.GetExtension(filenameTemplate);
@@ -143,16 +119,8 @@ namespace Serilog.Sinks.RollingFile
             }
         }
 
-        public DateTime GetCurrentCheckpoint(DateTime instant)
-        {
-            return _specifier.GetCurrentCheckpoint(instant);
-        }
+        public DateTime GetCurrentCheckpoint(DateTime instant) => _specifier.GetCurrentCheckpoint(instant);
 
-        public DateTime GetNextCheckpoint(DateTime instant)
-        {
-            return _specifier.GetNextCheckpoint(instant);
-        }
+        public DateTime GetNextCheckpoint(DateTime instant) => _specifier.GetNextCheckpoint(instant);
     }
-
-
 }

--- a/src/Serilog.Sinks.RollingFile/project.json
+++ b/src/Serilog.Sinks.RollingFile/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.1.1-*",
+  "version": "3.2.0-*",
   "description": "The rolling file sink for Serilog - Simple .NET logging with fully-structured events",
   "authors": [ "Serilog Contributors" ],
   "packOptions": {

--- a/src/Serilog.Sinks.RollingFile/project.json
+++ b/src/Serilog.Sinks.RollingFile/project.json
@@ -18,7 +18,7 @@
   },
   "frameworks": {
     "net4.5": {
-      "buildOptions": {"define": ["SHARING"]}
+      "buildOptions": {"define": ["SHARING", "HRESULTS"]}
     },
     "netstandard1.3": {
       "dependencies": {


### PR DESCRIPTION
- Fixed default namespace
- Added missing license header
- Don't try checking HRESULTS on .NET Core (fails on some Xamarin variants)
- Added more tests covering hour/half-hour rolling
- Rremoved 'old style' specifier check (this hasn't been used for several years)
- C# 6 usage
- Condensed some code
