### PR TITLE
Fixes #37 - sharing on .NET Core

### DIFF
--- a/src/Serilog.Sinks.RollingFile/Sinks/RollingFile/RollingFileSink.cs
+++ b/src/Serilog.Sinks.RollingFile/Sinks/RollingFile/RollingFileSink.cs
@@ -71,11 +71,6 @@ namespace Serilog.Sinks.RollingFile
             if (fileSizeLimitBytes.HasValue && fileSizeLimitBytes < 0) throw new ArgumentException("Negative value provided; file size limit must be non-negative");
             if (retainedFileCountLimit.HasValue && retainedFileCountLimit < 1) throw new ArgumentException("Zero or negative value provided; retained file count limit must be at least 1");
 
-#if !SHARING
-            if (shared)
-                throw new NotSupportedException("File sharing is not supported on this platform.");
-#endif
-
             _roller = new TemplatedPathRoller(pathFormat);
             _textFormatter = textFormatter;
             _fileSizeLimitBytes = fileSizeLimitBytes;
@@ -154,13 +149,9 @@ namespace Serilog.Sinks.RollingFile
 
                 try
                 {
-#if SHARING
                     _currentFile = _shared ?
                         (ILogEventSink)new SharedFileSink(path, _textFormatter, _fileSizeLimitBytes, _encoding) :
                         new FileSink(path, _textFormatter, _fileSizeLimitBytes, _encoding, _buffered);
-#else
-                    _currentFile = new FileSink(path, _textFormatter, _fileSizeLimitBytes, _encoding, _buffered);
-#endif
                 }
                 catch (IOException ex)
                 {

--- a/src/Serilog.Sinks.RollingFile/project.json
+++ b/src/Serilog.Sinks.RollingFile/project.json
@@ -9,7 +9,7 @@
     "iconUrl": "http://serilog.net/images/serilog-sink-nuget.png"
   },
   "dependencies": {
-    "Serilog.Sinks.File": "3.1.0"
+    "Serilog.Sinks.File": "3.2.0-dev-00762"
   },
   "buildOptions": {
     "keyFile": "../../assets/Serilog.snk",
@@ -18,7 +18,7 @@
   },
   "frameworks": {
     "net4.5": {
-      "buildOptions": {"define": ["SHARING", "HRESULTS"]}
+      "buildOptions": {"define": ["HRESULTS"]}
     },
     "netstandard1.3": {
       "dependencies": {


### PR DESCRIPTION
Takes a `-dev` dependency on _Serilog.Sinks.File_, which needs to be updated to the 3.2 version once it is released.