### PR TITLE
Modified readme.md to contain date placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,13 @@ log-20160702.txt
 
 > **Important:** By default, only one process may write to a log file at a given time. See _Shared log files_ below for information on multi-process sharing.
 
-### Date placeholders
+### format specifiers
 
-The Appender supports three different date time placeholders:
+The Appender supports three different format specifiers:
 
 * {Date} Creates a file per day. Filename uses the `yyyyMMdd` format.
-* {Hour} Creates a file per hour. Filename uses the `yyyyMMddhh24mi` format. 
-* {HalfHour} Creates a file per half hour. Filename uses the `yyyyMMddhh24mi` format. 
+* {Hour} Creates a file per hour. Filename uses the `yyyyMMddHH` format.
+* {HalfHour} Creates a file per half hour. Filename uses the `yyyyMMddHHmm` format.
 
 ### Limits
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ To configure the sink in C# code, call `WriteTo.RollingFile()` during logger con
 var log = new LoggerConfiguration()
     .WriteTo.RollingFile("log-{Date}.txt")
     .CreateLogger();
-    
+
 Log.Information("This will be written to the rolling file set");
 ```
 
@@ -33,6 +33,7 @@ log-20160702.txt
 ### Date placeholders
 
 The Appender supports three different date time placeholders:
+
 * {Date} Creates a file per day. Filename uses the `yyyyMMdd` format.
 * {Hour} Creates a file per hour. Filename uses the `yyyyMMddhh24mi` format. 
 * {HalfHour} Creates a file per half hour. Filename uses the `yyyyMMddhh24mi` format. 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ log-20160702.txt
 ```
 
 > **Important:** By default, only one process may write to a log file at a given time. See _Shared log files_ below for information on multi-process sharing.
+### Date placeholders
+
+The Appender supports three different date time placeholders:
+* {Date} Creates a file per day. Filename uses the `yyyyMMdd` format.
+* {Hour} Creates a file per hour. Filename uses the `yyyyMMddhh24mi` format. 
+* {HalfHour} Creates a file per half hour. Filename uses the `yyyyMMddhh24mi` format. 
 
 ### Limits
 

--- a/README.md
+++ b/README.md
@@ -30,13 +30,13 @@ log-20160702.txt
 
 > **Important:** By default, only one process may write to a log file at a given time. See _Shared log files_ below for information on multi-process sharing.
 
-### format specifiers
+### Format specifiers
 
-The Appender supports three different format specifiers:
+The sink supports three different format specifiers:
 
-* {Date} Creates a file per day. Filename uses the `yyyyMMdd` format.
-* {Hour} Creates a file per hour. Filename uses the `yyyyMMddHH` format.
-* {HalfHour} Creates a file per half hour. Filename uses the `yyyyMMddHHmm` format.
+* `{Date}` Creates a file per day. Filename uses the `yyyyMMdd` format.
+* `{Hour}` Creates a file per hour. Filename uses the `yyyyMMddHH` format.
+* `{HalfHour}` Creates a file per half hour. Filename uses the `yyyyMMddHHmm` format.
 
 ### Limits
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ log-20160702.txt
 ```
 
 > **Important:** By default, only one process may write to a log file at a given time. See _Shared log files_ below for information on multi-process sharing.
+
 ### Date placeholders
 
 The Appender supports three different date time placeholders:


### PR DESCRIPTION
I have added the missing placeholders for {Hour} and {HalfHour} into the readme.